### PR TITLE
Compatibility with other PlatformIO frameworks

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,26 @@
+{
+    "name": "FatFS",
+    "keywords": "Fat, FS, Storage",
+    "description": "FAT file system based on open-source FatFS solution",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/stm32duino/FatFs.git"
+    },
+    "version": "2.0.3",
+    "authors": [
+        {
+            "url": "http://elm-chan.org/fsw/ff/00index_e.html",
+            "maintainer": false,
+            "email": "user5@elm-chan.org",
+            "name": "Chan"
+        },
+        {
+            "url": "https://www.st.com/",
+            "maintainer": false,
+            "email": null,
+            "name": "STMicroelectronics"
+        }
+    ],
+    "frameworks": "*",
+    "platforms": "*"
+}


### PR DESCRIPTION
I'll give some background first. I'm trying to use the library on a PlatformIO project that uses the `stm32cube` framework. Despite of being available by default on STM32Cube and being generic code, PlatformIO will only use the library if the project uses the `arduino` framework. I think this is because it only has a `library.properties` file necessary to be discovered by the Arduino library tool.

This is the error I get:
```
$ pio run --verbose
[...]
Framework incompatible library $PROJECT_DIR/lib/FatFs
More details about "Library Compatibility Mode": https://docs.platformio.org/page/librarymanager/ldf.html#ldf-compat-mode
[...]
```

In any case, to overcome this problem I've just created a `library.json` which basically has the same content of `library.properties`. This has been successfully tested locally.

This PR contains a single commit:
> Add library.json so it can be used on PlatformIO with any framework and platform